### PR TITLE
Fix for broadcast IP address

### DIFF
--- a/WoL.sh
+++ b/WoL.sh
@@ -65,7 +65,7 @@ else
     
     # Send magic packet
     printf "Sending magic packet..." 
-    echo -e $magicpacket | nc -w1 -u $targetip $targetport
+    echo -e $magicpacket | nc -w1 -u -b $targetip $targetport
     printf " Done!"
     
 fi


### PR DESCRIPTION
The -b switch is required for the broadcast address to be interpreted properly